### PR TITLE
Update npm start command + Postgres instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Uncomment the `smtp` setting and update the keys with your personal email creden
 
 ## Database setup
 
+Make sure you have an instance of Postgres running.
+
+If you don't want to run a Postgres instance from the command line you can also install the [Postgres app](https://postgresapp.com/downloads.html).
+
 ```
 $ cd db/
 $ make setup

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ cd ssl && openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 365 
 Just go into the project folder and load up the server with `npm run`.
 
 ```
-$ npm run
+$ npm run start
 ```
 
 Load it up in a browser! By default it can be reached from `https://localhost:5000/`. If you used a self-signed SSL certificate you will need to click through a security warning.


### PR DESCRIPTION
When I run `npm run` without `start` the local server doesn't boot up.

Copy and pasted from terminal:
```
Lifecycle scripts included in organizer.network:
start
node organizer.network.js
```