### PR TITLE
organizer.network.js → app.js server.js start.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,26 +11,12 @@ if (! fs.existsSync(`${__dirname}/config.js`)) {
 	console.log('Please set up config.js');
 	return;
 }
-const config = require('./config.js');
+const config = require('./config');
 
 // server
 const express = require('express');
 const app = express();
-var server;
 
-if ('ssl' in config) {
-	// Setup HTTPS server
-	let https_options = {};
-	for (let key in config.ssl) {
-		https_options[key] = fs.readFileSync(`${__dirname}/${config.ssl[key]}`);
-	}
-	server = require('https').createServer(https_options, app);
-} else {
-	// Setup HTTP server
-	server = require('http').createServer(app);
-}
-
-const io = require('socket.io')(server);
 const body_parser = require('body-parser');
 const marked = require('marked');
 const yaml = require('js-yaml');
@@ -49,19 +35,6 @@ const slug_regex = /^[a-z][a-z0-9_-]+$/i;
 marked.setOptions({
 	gfm: true,
 	smartypants: true
-});
-
-// Setup CORS
-io.origins((origin, callback) => {
-	if (config.cors_origins.indexOf('*') !== -1) {
-		callback(null, true);
-	} else if (config.cors_origins.indexOf(origin) !== -1 ||
-	           config.cors_origins.indexOf(origin + '/') !== -1) {
-		callback(null, true);
-	} else {
-		console.log(`CORS blocked origin: ${origin}`);
-		return callback('origin not allowed', false);
-	}
 });
 
 app.set('view engine', 'ejs');
@@ -91,10 +64,6 @@ app.use((req, rsp, next) => {
 	next();
 });
 app.enable('trust proxy');
-
-server.listen(config.port, () => {
-	console.log(`listening on *:${config.port}`);
-});
 
 // Connect to PostgreSQL
 const pg = require('pg');
@@ -2424,3 +2393,5 @@ function random(count, is_slug) {
 
 	return value.join('');
 }
+
+module.exports = app;

--- a/bin/start.js
+++ b/bin/start.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../server')();

--- a/config.js.example
+++ b/config.js.example
@@ -1,9 +1,9 @@
 module.exports = {
 
-	ssl: {
+	/*ssl: {
 		key: "ssl/key.pem",
 		cert: "ssl/cert.pem"
-	},
+	},*/
 
 	cors_origins: [
 		"*"

--- a/config.js.example
+++ b/config.js.example
@@ -9,7 +9,7 @@ module.exports = {
 		"*"
 	],
 
-	base_url: 'https://localhost:5000',
+	base_url: 'http://localhost:5000',
 	port: 5000,
 	db_dsn: "postgres://localhost:5432/jiji",
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,6 +179,12 @@
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
     "base64-arraybuffer": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
@@ -243,6 +249,22 @@
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         }
       }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
     },
     "buffer-alloc": {
       "version": "1.2.0",
@@ -384,6 +406,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -398,6 +426,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -442,6 +476,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -543,6 +583,12 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -784,6 +830,12 @@
         }
       }
     },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+      "dev": true
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -812,6 +864,12 @@
         "minipass": "^2.2.1"
       }
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -839,6 +897,26 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -884,6 +962,12 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
     "http-errors": {
       "version": "1.6.3",
       "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -917,6 +1001,16 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -1050,6 +1144,15 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
     "minimist": {
       "version": "1.2.0",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -1091,6 +1194,45 @@
           "version": "0.0.8",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -1241,6 +1383,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -1749,6 +1897,57 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "supertest": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.3.0.tgz",
+      "integrity": "sha512-dMQSzYdaZRSANH5LL8kX3UpgK9G1LRh/jnggs/TI0W2Sz7rkMx9Y48uia3K9NgcaWEV28tYkBnXE4tiFC77ygQ==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^3.8.3"
+      }
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Tools and strategies for social justice organizing",
   "main": "app.js",
   "scripts": {
-    "start": "./bin/start.js"
+    "start": "./bin/start.js",
+    "test": "mocha"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tools and strategies for social justice organizing",
   "main": "app.js",
   "scripts": {
-    "start": "node app.js"
+    "start": "./bin/start.js"
   },
   "repository": {
     "type": "git",
@@ -36,5 +36,9 @@
     "sharp": "^0.21.0",
     "socket.io": "^2.1.1",
     "source-sans-pro": "^2.40.0"
+  },
+  "devDependencies": {
+    "mocha": "^5.2.0",
+    "supertest": "^3.3.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -37,4 +37,6 @@ module.exports = () => {
 		}
 	});
 
+	return server;
+
 };

--- a/server.js
+++ b/server.js
@@ -1,0 +1,40 @@
+module.exports = () => {
+
+	let server;
+
+	const fs = require('fs');
+	const config = require('./config');
+	const app = require('./app');
+
+	if ('ssl' in config) {
+		// Setup HTTPS server
+		let https_options = {};
+		for (let key in config.ssl) {
+			https_options[key] = fs.readFileSync(`${__dirname}/${config.ssl[key]}`);
+		}
+		server = require('https').createServer(https_options, app);
+	} else {
+		// Setup HTTP server
+		server = require('http').createServer(app);
+	}
+
+	server.listen(config.port, () => {
+		console.log(`listening on *:${config.port}`);
+	});
+
+	const io = require('socket.io')(server);
+
+	// Setup CORS
+	io.origins((origin, callback) => {
+		if (config.cors_origins.indexOf('*') !== -1) {
+			callback(null, true);
+		} else if (config.cors_origins.indexOf(origin) !== -1 ||
+		           config.cors_origins.indexOf(origin + '/') !== -1) {
+			callback(null, true);
+		} else {
+			console.log(`CORS blocked origin: ${origin}`);
+			return callback('origin not allowed', false);
+		}
+	});
+
+};

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,20 @@
+var request = require('supertest');
+describe('loading express', function () {
+	var server;
+	beforeEach(function () {
+		server = require('../server')();
+	});
+	afterEach(function () {
+		server.close();
+	});
+	it('responds to /', function test_home(done) {
+		request(server)
+		.get('/')
+		.expect(200, done);
+	});
+	it('404 everything else', function test_404(done) {
+		request(server)
+		.get('/foo/bar')
+		.expect(404, done);
+	});
+});


### PR DESCRIPTION
This is the first step of the refactor process of splitting apart `organizer.network.js`. Here is a summary of what this PR contains:

* `organizer.network.js` has been renamed `app.js`
* new file: [ecosystem.config.js for pm2](https://pm2.io/doc/en/runtime/guide/ecosystem-file/)
* `server.js` exports a function that takes `app.js` and runs it as an actual server
* `start.js` takes that function from `server.js` and executes it
* `test/server.js` uses [mocha](https://mochajs.org/) and [supertest](https://www.npmjs.com/package/supertest) to check that the server is running and responds 200 for `/` and 404 for `/foo/bar`

Here is how to test this out:

```
$ git checkout dphiffer/refactor2
$ npm install 
$ npm test
```

Question: does anyone know why the test doesn't exit when it finishes? It just kind of sits there after the tests pass. I feel like it might be related to `async` or promises?