### PR TITLE
Two small fixes

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -479,6 +479,15 @@ const self = {
 				let ids = contexts.map(ctx => parseInt(ctx.id));
 				let placeholders = [];
 
+				if (ids.length == 0) {
+					return resolve({
+						ids: ids,
+						messages: [],
+						groups: [],
+						total_messages: 0
+					})
+				}
+
 				for (let id of ids) {
 					placeholders.push('$' + (placeholders.length + 1));
 				}

--- a/views/message-page.ejs
+++ b/views/message-page.ejs
@@ -6,9 +6,14 @@
 			<h2 class="group">
 				<% if (group.parent_id) { %>
 					<% let parent = context.groups[group.parent_id] %>
-					<% context.slug = `${parent.slug}/${group.slug}` %>
-					<a href="/group/<%= parent.slug %>"><%= parent.name %></a>
-					→ <a href="/group/<%= parent.slug %>/<%= group.slug %>"><%= group.name %></a>
+					<% if (parent) { %>
+						<% context.slug = `${parent.slug}/${group.slug}` %>
+						<a href="/group/<%= parent.slug %>"><%= parent.name %></a>
+						→ <a href="/group/<%= parent.slug %>/<%= group.slug %>"><%= group.name %></a>
+					<% } else { %>
+						<% context.slug = group.slug %>
+						<a href="/group/<%= group.slug %>"><%= group.name %></a>
+					<% } %>
 				<% } else { %>
 					<% context.slug = group.slug %>
 					<a href="/group/<%= group.slug %>"><%= group.name %></a>


### PR DESCRIPTION
- Make sure the parent group exists before rendering a link to it (this one is still somewhat mysterious)
- Check that placeholder in a `WHERE column IN (${placeholders})` part of the query is not empty